### PR TITLE
#46: cmake: add option to disable Python when building with VT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 message(STATUS "CMAKE_CXX_STANDARD: ${CMAKE_CXX_STANDARD}")
 
+option(vt_tv_python_bindings_enabled "Build vt-tv with Python bindings" ON)
+
 include(cmake/load_packages.cmake)
 
 add_custom_target(vt_tv_examples)
@@ -59,31 +61,33 @@ install(
   COMPONENT    lib
 )
 
-# Build the core parts of nanobind once
-nanobind_build_library(nanobind SHARED)
+if (vt_tv_python_bindings_enabled)
+  # Build the core parts of nanobind once
+  nanobind_build_library(nanobind SHARED)
 
-# Compile an extension library
-add_library(my_ext MODULE ${CMAKE_CURRENT_SOURCE_DIR}/circle.cc)
+  # Compile an extension library
+  add_library(my_ext MODULE ${CMAKE_CURRENT_SOURCE_DIR}/circle.cc)
 
-# .. and link it against the nanobind parts
-message(STATUS "vtk libraries: ${VTK_LIBRARIES}")
-target_link_libraries(my_ext PUBLIC ${VTK_LIBRARIES})
-target_link_libraries(my_ext PRIVATE nanobind)
+  # .. and link it against the nanobind parts
+  message(STATUS "vtk libraries: ${VTK_LIBRARIES}")
+  target_link_libraries(my_ext PUBLIC ${VTK_LIBRARIES})
+  target_link_libraries(my_ext PRIVATE nanobind)
 
-# .. enable size optimizations
-nanobind_opt_size(my_ext)
+  # .. enable size optimizations
+  nanobind_opt_size(my_ext)
 
-# .. enable link time optimization
-nanobind_lto(my_ext)
+  # .. enable link time optimization
+  nanobind_lto(my_ext)
 
-# .. disable the stack protector
-nanobind_disable_stack_protector(my_ext)
+  # .. disable the stack protector
+  nanobind_disable_stack_protector(my_ext)
 
-# .. set the Python extension suffix
-nanobind_extension(my_ext)
+  # .. set the Python extension suffix
+  nanobind_extension(my_ext)
 
-# .. set important compilation flags
-nanobind_compile_options(my_ext)
+  # .. set important compilation flags
+  nanobind_compile_options(my_ext)
 
-# .. set important linker flags
-nanobind_link_options(my_ext)
+  # .. set important linker flags
+  nanobind_link_options(my_ext)
+endif()

--- a/cmake/load_packages.cmake
+++ b/cmake/load_packages.cmake
@@ -1,24 +1,33 @@
 
 # json library always included in the build
-set(JSON_BuildTests OFF)
-set(JSON_MultipleHeaders ON)
-set(JSON_LIBRARY nlohmann_json)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lib/json)
+if (NOT TARGET nlohmann_json)
+  set(JSON_BuildTests OFF)
+  set(JSON_MultipleHeaders ON)
+  set(JSON_LIBRARY nlohmann_json)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lib/json)
+endif()
 
 # fmt always included in the build
-set(FMT_LIBRARY fmt)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lib/fmt)
+if (NOT TARGET fmt)
+  set(FMT_LIBRARY fmt)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lib/fmt)
+endif()
 
-# brotli library always included in the build
-set(BROTLI_DISABLE_TESTS ON)
-# we need to disable bundled mode so it will install properly
-set(BROTLI_BUNDLED_MODE OFF)
-set(BROTLI_BUILD_PORTABLE ON)
-set(BROTLI_LIBRARY brotlicommon-static brotlienc-static brotlidec-static)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lib/brotli)
+if (NOT TARGET brotli)
+  # brotli library always included in the build
+  set(BROTLI_DISABLE_TESTS ON)
+  # we need to disable bundled mode so it will install properly
+  set(BROTLI_BUNDLED_MODE OFF)
+  set(BROTLI_BUILD_PORTABLE ON)
+  set(BROTLI_LIBRARY brotlicommon-static brotlienc-static brotlidec-static)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lib/brotli)
+endif()
 
 set(YAML_LIBRARY yaml-cpp)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lib/yaml-cpp)
 
 include(cmake/load_vtk_package.cmake)
-include(cmake/load_nanobind_package.cmake)
+
+if (vt_tv_python_bindings_enabled)
+  include(cmake/load_nanobind_package.cmake)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,9 @@
 set(BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject" FORCE)
 set(INSTALL_GTEST OFF CACHE BOOL "Enable installation of googletest. (Projects embedding googletest may want to turn this OFF.)" FORCE)
 
-add_subdirectory(extern/googletest)
+if (NOT TARGET gtest)
+  add_subdirectory(extern/googletest)
+endif()
 set(GOOGLETEST_LIBRARY gtest)
 
 # Hide various options from UI-based property editors

--- a/tests/unit/cmake_config.h
+++ b/tests/unit/cmake_config.h
@@ -1,1 +1,1 @@
-#define SRC_DIR "/Users/pierrepebay/Develop/vt-tv"
+#define SRC_DIR "/vt/lib/vt-tv"


### PR DESCRIPTION
Fixes #46