### PR TITLE
#48: api: compile-time error, cleanup, add serializers

### DIFF
--- a/examples/example-yaml-file.yaml
+++ b/examples/example-yaml-file.yaml
@@ -1,9 +1,12 @@
-LBAF_Viz:
+viz:
   x_ranks: 2
   y_ranks: 2
   z_ranks: 1
   object_jitter: 0.5
-  rank_qoi: work
+  rank_qoi: load
   object_qoi: load
   save_meshes: True
   force_continuous_object_qoi: True
+output:
+  directory: /build/vt/
+  file_stem: viz

--- a/src/vt-tv/api/info.h
+++ b/src/vt-tv/api/info.h
@@ -132,7 +132,7 @@ struct Info {
    */
   uint64_t getNumPhases() const {
     uint64_t n_phases = this->ranks_.at(0).getNumPhases();
-    for (NodeType rank_id = 1; rank_id < this->ranks_.size(); rank_id++) {
+    for (NodeType rank_id = 1; rank_id < static_cast<NodeType>(this->ranks_.size()); rank_id++) {
       if (ranks_.at(rank_id).getNumPhases() != n_phases) {
         throw std::runtime_error("Number of phases must be consistent across ranks");
       }

--- a/src/vt-tv/api/info.h
+++ b/src/vt-tv/api/info.h
@@ -72,7 +72,7 @@ struct Info {
       ranks_(std::move(in_ranks))
   { }
 
-  Info() { };
+  Info() = default;
 
   /**
    * \brief Add more information about a new rank

--- a/src/vt-tv/api/info.h
+++ b/src/vt-tv/api/info.h
@@ -370,6 +370,17 @@ struct Info {
     }
   }
 
+  /**
+   * \brief Serializer for data
+   *
+   * \param[in] s the serializer
+   */
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    s | object_info_;
+    s | ranks_;
+  }
+
 private:
   /// All the object info that doesn't change across phases
   std::unordered_map<ElementIDType, ObjectInfo> object_info_;

--- a/src/vt-tv/api/info.h
+++ b/src/vt-tv/api/info.h
@@ -173,8 +173,8 @@ struct Info {
     std::unordered_map<PhaseType, double> rank_loads;
 
     auto const& rank = this->ranks_.at(rank_id);
-    uint64_t n_phases = rank.getNumPhases();
-    for (uint64_t phase = 0; phase < n_phases; phase++) {
+    auto const& phase_work = rank.getPhaseWork();
+    for (auto const& [phase, _] : phase_work) {
       rank_loads.insert(std::make_pair(phase, rank.getLoad(phase)));
     }
 

--- a/src/vt-tv/api/object_communicator.h
+++ b/src/vt-tv/api/object_communicator.h
@@ -154,6 +154,18 @@ struct ObjectCommunicator {
     }
   }
 
+  /**
+   * \brief Serializer for data
+   *
+   * \param[in] s the serializer
+   */
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    s | object_id_;
+    s | received_;
+    s | sent_;
+  }
+
 private:
   ElementIDType object_id_;                  /**< The object id */
   std::map<ElementIDType, double> received_; /**< The received edges */

--- a/src/vt-tv/api/object_communicator.h
+++ b/src/vt-tv/api/object_communicator.h
@@ -17,17 +17,41 @@ namespace vt::tv {
 struct Object;
 
 /**
- *  A class holding received and sent messages for an object.
+ * \struct ObjectCommunicator
+ *
+ * \brief A class holding received and sent messages for an object.
  */
-struct ObjectCommunicator
-{
-private:
-  ElementIDType object_id_;
-  std::map<ElementIDType, double> received_;
-  std::map<ElementIDType, double> sent_;
+struct ObjectCommunicator {
 
   /**
-   * Summarize one-way communicator properties and check for errors.
+   * \brief Construct an \c ObjectCommunicator without any edges
+   *
+   * \param[in] id_in the object id
+   */
+  explicit ObjectCommunicator(ElementIDType id_in)
+    : object_id_(id_in)
+  {}
+
+  /**
+   * \brief Construct an \c ObjectCommunicator with edges
+   *
+   * \param[in] id_in the object id
+   * \param[in] recv_in receive edges
+   * \param[in] sent_in send edges
+   */
+  ObjectCommunicator(
+    ElementIDType id_in,
+    std::map<ElementIDType, double> recv_in,
+    std::map<ElementIDType, double> sent_in
+  ) : object_id_(id_in),
+      received_(recv_in),
+      sent_(sent_in)
+  { }
+
+  /**
+   * \brief Summarize one-way communicator properties and check for errors.
+   *
+   * \param[in] direction the direction to summarize edges
    */
   std::vector<double> summarizeUnidirectional(std::string direction) const {
     // Initialize list of volumes
@@ -53,40 +77,42 @@ private:
 
     return volumes;
   }
-public:
+
   /**
-   * \brief get id of object for this communicator
+   * \brief Get the id of object for this communicator
    *
    * \return id
    */
   ElementIDType getObjectId() const { return object_id_; };
 
   /**
-   * Return all from_object=volume pairs received by object.
+   * \brief Return all from_object=volume pairs received by object.
    */
-  std::map<ElementIDType, double> getReceived() const { return this->received_; };
+  std::map<ElementIDType, double> getReceived() const {
+    return this->received_;
+  };
 
   /**
-   * Return the volume of a message received from an object if any.
+   * \brief Return the volume of a message received from an object if any.
    */
   double getReceivedFromObject(ElementIDType id) const {
     return this->received_.at(id);
   }
 
   /**
-   * Return all to_object=volume pairs sent from object.
+   * \brief Return all to_object=volume pairs sent from object.
    */
   std::map<ElementIDType, double> getSent() const { return this->sent_; };
 
   /**
-   * Return the volume of a message sent to an object if any.
+   * \brief Return the volume of a message sent to an object if any.
    */
   double getSentToObject(ElementIDType id) const {
     return this->sent_.at(id);
   }
 
   /**
-   * Summarize communicator properties and check for errors.
+   * \brief Summarize communicator properties and check for errors.
    */
   std::pair<std::vector<double>, std::vector<double>> summarize() const {
     // Summarize sent communications
@@ -98,29 +124,40 @@ public:
     return std::make_pair(w_sent, w_recv);
   }
 
+  /**
+   * \brief Add received edge
+   *
+   * \param[in] from_id the from object id
+   * \param[in] bytes the number of bytes
+   */
   void addReceived(ElementIDType from_id, double bytes) {
     this->received_.insert(std::make_pair(from_id, bytes));
-    if (from_id == this->object_id_) fmt::print("Object {} receiving communication from myself\n",this->object_id_);
+    if (from_id == this->object_id_) {
+      fmt::print(
+        "Object {} receiving communication from myself\n", this->object_id_
+      );
+    }
   }
 
+  /**
+   * \brief Add sent edge
+   *
+   * \param[in] to_id the to object id
+   * \param[in] bytes the number of bytes
+   */
   void addSent(ElementIDType to_id, double bytes) {
     this->sent_.insert(std::make_pair(to_id, bytes));
-    if (to_id == this->object_id_) fmt::print("Object {} sending communication to myself\n",this->object_id_);
+    if (to_id == this->object_id_) {
+      fmt::print(
+        "Object {} sending communication to myself\n", this->object_id_
+      );
+    }
   }
 
-  ObjectCommunicator(ElementIDType id_in)
-  : object_id_(id_in)
-  , received_()
-  , sent_()
-  {}
-  ObjectCommunicator(ElementIDType id_in,
-                      std::map<ElementIDType, double> recv_in,
-                      std::map<ElementIDType, double> sent_in)
-  : object_id_(id_in)
-  , received_(recv_in)
-  , sent_(sent_in)
-  {}
-  ~ObjectCommunicator() = default;
+private:
+  ElementIDType object_id_;                  /**< The object id */
+  std::map<ElementIDType, double> received_; /**< The received edges */
+  std::map<ElementIDType, double> sent_;     /**< The sent edges */
 };
 
 } /* end namesapce vt::tv */

--- a/src/vt-tv/api/object_communicator.h
+++ b/src/vt-tv/api/object_communicator.h
@@ -23,6 +23,8 @@ struct Object;
  */
 struct ObjectCommunicator {
 
+  ObjectCommunicator() = default;
+
   /**
    * \brief Construct an \c ObjectCommunicator without any edges
    *

--- a/src/vt-tv/api/object_info.h
+++ b/src/vt-tv/api/object_info.h
@@ -58,6 +58,8 @@ namespace vt::tv {
  */
 struct ObjectInfo {
 
+  ObjectInfo() = default;
+
   /**
    * \brief Construct information about an object
    *

--- a/src/vt-tv/api/object_info.h
+++ b/src/vt-tv/api/object_info.h
@@ -153,6 +153,22 @@ struct ObjectInfo {
    */
   CollectionObjGroupIDType getMetaID() const { return meta_id_; }
 
+  /**
+   * \brief Serializer for data
+   *
+   * \param[in] s the serializer
+   */
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    s | id_;
+    s | home_;
+    s | migratable_;
+    s | index_;
+    s | meta_id_;
+    s | is_objgroup_;
+    s | is_collection_;
+  }
+
 private:
   /// Unique identifier across all ranks for the object
   ElementIDType id_ = 0;

--- a/src/vt-tv/api/object_work.h
+++ b/src/vt-tv/api/object_work.h
@@ -63,6 +63,8 @@ struct ObjectWork {
   /// Possible user-defined types for a task
   using VariantType = std::variant<int, double, std::string>;
 
+  ObjectWork() = default;
+
   /**
    * \brief Construct \c ObjectWork for a given phase
    *

--- a/src/vt-tv/api/object_work.h
+++ b/src/vt-tv/api/object_work.h
@@ -153,6 +153,20 @@ struct ObjectWork {
     return communicator_.getSent();
   }
 
+  /**
+   * \brief Serializer for data
+   *
+   * \param[in] s the serializer
+   */
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    s | id_;
+    s | whole_phase_load_;
+    s | subphase_loads_;
+    s | user_defined_;
+    s | communicator_;
+  }
+
 private:
   /// Element ID
   ElementIDType id_ = 0;

--- a/src/vt-tv/api/phase_work.h
+++ b/src/vt-tv/api/phase_work.h
@@ -58,6 +58,8 @@ namespace vt::tv {
  */
 struct PhaseWork {
 
+  PhaseWork() = default;
+
   /**
    * \brief Construct phase work
    *

--- a/src/vt-tv/api/phase_work.h
+++ b/src/vt-tv/api/phase_work.h
@@ -105,6 +105,17 @@ struct PhaseWork {
    */
   void setCommunications(ElementIDType o_id, ObjectCommunicator& c) { objects_.at(o_id).setCommunications(c); };
 
+  /**
+   * \brief Serializer for data
+   *
+   * \param[in] s the serializer
+   */
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    s | phase_;
+    s | objects_;
+  }
+
 private:
   /// Phase identifier
   PhaseType phase_ = 0;

--- a/src/vt-tv/api/rank.h
+++ b/src/vt-tv/api/rank.h
@@ -55,6 +55,8 @@ namespace vt::tv {
  */
 struct Rank {
 
+  Rank() = default;
+
   /**
    * \brief Construct a rank data
    *

--- a/src/vt-tv/api/rank.h
+++ b/src/vt-tv/api/rank.h
@@ -96,6 +96,17 @@ struct Rank {
    */
   double getLoad(PhaseType phase) const { return phase_info_.at(phase).getLoad(); }
 
+  /**
+   * \brief Serializer for data
+   *
+   * \param[in] s the serializer
+   */
+  template <typename SerializerT>
+  void serialize(SerializerT& s) {
+    s | rank_;
+    s | phase_info_;
+  }
+
 private:
   /// The rank ID
   NodeType rank_ = 0;

--- a/src/vt-tv/render/render.h
+++ b/src/vt-tv/render/render.h
@@ -143,6 +143,8 @@ private:
   double object_jitter_ = 0.5;
   std::unordered_map<ElementIDType, std::array<double, 3>> jitter_dims_;
 
+  PhaseType selected_phase_;
+
   /**
    * \brief Compute range of object qoi.
    *
@@ -215,14 +217,15 @@ public:
   /**
    * \brief Construct render
    *
-  * \param[in] in_qoi_request description of rank and object quantities of interest
-  * \param[in] in_continuous_object_qoi always treat object QOI as continuous or not
-  * \param[in] in_info general info
-  * \param[in] in_grid_size triplet containing grid sizes in each dimension
-  * \param[in] in_object_jitter coefficient of random jitter with magnitude < 1
-  * \param[in] in_output_dir output directory
-  * \param[in] in_output_file_stem file name stem
-  * \param[in] in_resolution grid_resolution value
+   * \param[in] in_qoi_request description of rank and object quantities of interest
+   * \param[in] in_continuous_object_qoi always treat object QOI as continuous or not
+   * \param[in] in_info general info
+   * \param[in] in_grid_size triplet containing grid sizes in each dimension
+   * \param[in] in_object_jitter coefficient of random jitter with magnitude < 1
+   * \param[in] in_output_dir output directory
+   * \param[in] in_output_file_stem file name stem
+   * \param[in] in_resolution grid_resolution value
+   * \param[in] in_selected_phase the phase selected (if max then render all)
    */
   Render(
     std::array<std::string, 3> in_qoi_request,
@@ -233,7 +236,8 @@ public:
     std::string in_output_dir,
     std::string in_output_file_stem,
     double in_resolution,
-    bool in_save_meshes
+    bool in_save_meshes,
+    PhaseType in_selected_phase = std::numeric_limits<PhaseType>::max()
   );
 
   static void createPipeline(

--- a/src/vt-tv/utility/parse_render.cc
+++ b/src/vt-tv/utility/parse_render.cc
@@ -1,0 +1,135 @@
+/*
+//@HEADER
+// *****************************************************************************
+//
+//                               parse_render.cc
+//             DARMA/vt-tv => Virtual Transport -- Task Visualizer
+//
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact darma@sandia.gov
+//
+// *****************************************************************************
+//@HEADER
+*/
+
+#include "vt-tv/utility/parse_render.h"
+#include "vt-tv/utility/json_reader.h"
+#include "vt-tv/render/render.h"
+
+#include "../tests/unit/cmake_config.h"
+
+#include <filesystem>
+
+namespace vt::tv::utility {
+
+void ParseRender::parseAndRender(PhaseType phase_id) {
+  try {
+    // Load the yaml file
+    YAML::Node config = YAML::LoadFile(filename_);
+
+    std::string input_dir = config["input"]["directory"].as<std::string>();
+    std::filesystem::path input_path(input_dir);
+
+    // If it's a relative path, prepend the SRC_DIR
+    if(input_path.is_relative()) {
+      input_path = std::filesystem::path(SRC_DIR) / input_path;
+    }
+    input_dir = input_path.string();
+
+    // append / to avoid problems with file stems
+    if (!input_dir.empty() && input_dir.back() != '/') {
+      input_dir += '/';
+    }
+
+    uint64_t n_ranks = config["input"]["n_ranks"].as<uint64_t>();
+
+    std::array<std::string, 3> qoi_request = {
+      config["viz"]["rank_qoi"].as<std::string>(),
+      "",
+      config["viz"]["object_qoi"].as<std::string>()
+    };
+
+    bool save_meshes = config["viz"]["save_meshes"].as<bool>();
+    bool continuous_object_qoi = config["viz"]["force_continuous_object_qoi"].as<bool>();
+
+    std::array<uint64_t, 3> grid_size = {
+      config["viz"]["x_ranks"].as<uint64_t>(),
+      config["viz"]["y_ranks"].as<uint64_t>(),
+      config["viz"]["z_ranks"].as<uint64_t>()
+    };
+
+    double object_jitter = config["viz"]["object_jitter"].as<double>();
+
+    std::string output_dir = config["output"]["directory"].as<std::string>();
+    std::filesystem::path output_path(output_dir);
+
+    // If it's a relative path, prepend the SRC_DIR
+    if (output_path.is_relative()) {
+      output_path = std::filesystem::path(SRC_DIR) / output_path;
+    }
+    output_dir = output_path.string();
+
+    // append / to avoid problems with file stems
+    if (!output_dir.empty() && output_dir.back() != '/') {
+      output_dir += '/';
+    }
+
+    std::string output_file_stem = config["output"]["file_stem"].as<std::string>();
+
+    // Read JSON file and input data
+    std::filesystem::path p = input_dir;
+    std::string path = std::filesystem::absolute(p).string();
+
+    std::unique_ptr<Info> info = std::make_unique<Info>();
+
+    for (NodeType rank = 0; rank < n_ranks; rank++) {
+      utility::JSONReader reader{rank, input_dir + "data." + std::to_string(rank) + ".json"};
+      reader.readFile();
+      auto tmpInfo = reader.parseFile();
+      info->addInfo(tmpInfo->getObjectInfo(), tmpInfo->getRank(rank));
+    }
+
+    fmt::print("Num ranks={}\n", info->getNumRanks());
+
+    // Instantiate render
+    Render r(
+      qoi_request, continuous_object_qoi, *info, grid_size, object_jitter,
+      output_dir, output_file_stem, 1.0, save_meshes
+    );
+    r.generate();
+
+  } catch (std::exception const& e) {
+    std::cout << "Error reading the configuration file: " << e.what() << std::endl;
+  }
+}
+
+} /* end namesapce vt::tv::utility */

--- a/src/vt-tv/utility/parse_render.cc
+++ b/src/vt-tv/utility/parse_render.cc
@@ -127,7 +127,7 @@ void ParseRender::parseAndRender(PhaseType phase_id, std::unique_ptr<Info> info)
     // Instantiate render
     Render r(
       qoi_request, continuous_object_qoi, *info, grid_size, object_jitter,
-      output_dir, output_file_stem, 1.0, save_meshes
+      output_dir, output_file_stem, 1.0, save_meshes, phase_id
     );
     r.generate();
 

--- a/src/vt-tv/utility/parse_render.h
+++ b/src/vt-tv/utility/parse_render.h
@@ -2,7 +2,7 @@
 //@HEADER
 // *****************************************************************************
 //
-//                                example2.cc
+//                               parse_render.h
 //             DARMA/vt-tv => Virtual Transport -- Task Visualizer
 //
 // Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
@@ -41,40 +41,48 @@
 //@HEADER
 */
 
-#include <vt-tv/api/info.h>
-#include <vt-tv/utility/json_reader.h>
-#include <vt-tv/render/render.h>
-#include <vt-tv/utility/parse_render.h>
-#include "../tests/unit/cmake_config.h"
+#if !defined INCLUDED_VT_TV_UTILITY_PARSE_RENDER_H
+#define INCLUDED_VT_TV_UTILITY_PARSE_RENDER_H
 
-#include <fmt-vt/format.h>
-#include <CLI/CLI11.hpp>
+#include "vt-tv/api/info.h"
 
-int main(int argc, char** argv) {
-  using namespace vt;
-  using namespace tv;
+#include <yaml-cpp/yaml.h>
 
-  CLI::App app{"TV: Task Visualizer"};
+#include <limits>
 
-  std::string default_config_file = "config/conf.yaml";
-  app.add_option("-c,--conf", default_config_file, "Input configuration file")->required();
+namespace vt::tv::utility {
 
-  CLI11_PARSE(app, argc, argv);
+/**
+ * \struct ParseRender
+ *
+ * \brief Parse YAML file and render based on configuration
+ */
+struct ParseRender {
 
-  std::string yaml_file = app.get_option("-c")->as<std::string>();
-  std::filesystem::path config_file_path(yaml_file);
+  /**
+   * \brief Construct the class
+   *
+   * \param[in] in_filename the yaml file name to read
+   */
+  ParseRender(std::string const& in_filename)
+    : filename_(in_filename)
+  { }
 
-  // If it's a relative path, prepend the SRC_DIR
-  if (config_file_path.is_relative()) {
-    config_file_path = std::filesystem::path(SRC_DIR) / config_file_path;
-  }
-  yaml_file = config_file_path.string();
+  /**
+   * \brief Parse yaml file and render 
+   *
+   * \param[in] phase_id the phase ID
+   *
+   * \note If \c phase_id is max then all phases will be rendered
+   */
+  void parseAndRender(
+    PhaseType phase_id = std::numeric_limits<PhaseType>::max()
+  );
 
-  fmt::print("Input configuration file={}\n", yaml_file);
+private:
+  std::string filename_;
+};
 
-  utility::ParseRender pr{yaml_file};
-  pr.parseAndRender();
+} /* end namesapce vt::tv::utility */
 
-
-  return 0;
-}
+#endif /*INCLUDED_VT_TV_UTILITY_PARSE_RENDER_H*/

--- a/src/vt-tv/utility/parse_render.h
+++ b/src/vt-tv/utility/parse_render.h
@@ -49,6 +49,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include <limits>
+#include <memory>
 
 namespace vt::tv::utility {
 
@@ -69,14 +70,16 @@ struct ParseRender {
   { }
 
   /**
-   * \brief Parse yaml file and render 
+   * \brief Parse yaml file and render
    *
    * \param[in] phase_id the phase ID
+   * \param[in] info the data to render
    *
    * \note If \c phase_id is max then all phases will be rendered
    */
   void parseAndRender(
-    PhaseType phase_id = std::numeric_limits<PhaseType>::max()
+    PhaseType phase_id = std::numeric_limits<PhaseType>::max(),
+    std::unique_ptr<Info> info = nullptr
   );
 
 private:


### PR DESCRIPTION
Fixes #48

- Fixes a compile-time error when compiling with VT
- Reformat and cleanup the `ObjectCommunicator`
- Add serializers to all the data structures stemming from `vt::tv::Info`
- Factor out YAML file parse and render functionality to utility for use in VT