### PR TITLE
#83: Disable python bindings by default for standalone build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 message(STATUS "CMAKE_CXX_STANDARD: ${CMAKE_CXX_STANDARD}")
 
-option(VT_TV_PYTHON_BINDINGS_ENABLED "Build vt-tv with Python bindings" ON)
+option(VT_TV_PYTHON_BINDINGS_ENABLED "Build vt-tv with Python bindings" OFF)
 option(VT_TV_OPENMP_ENABLED "Build vt-tv with openMP support" ON)
 set(VT_TV_N_THREADS "2" CACHE STRING "Number of OpenMP threads to use")
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ class CMakeBuild(build_ext):
 
     cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
                   '-DPYTHON_EXECUTABLE=' + sys.executable,
+                  '-DVT_TV_PYTHON_BINDINGS_ENABLED=ON',
                   '-DVTK_DIR=' + vtk_dir,
                   '-DVT_TV_N_THREADS=' + str(n_threads)]
 


### PR DESCRIPTION
Fixes #83 