### PR TITLE
#135: Add file name expression matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,57 @@ A YAML configuration exemplar can be found in `${VTTV_SOURCE_DIR}/config/conf.ya
 ${VTTV_BUILD_DIR}/apps/vt_standalone -c config/conf.yaml
 ```
 
+The following is a complete description of possible keys that can be used in a configuration file:
+
+```yaml
+input:
+  # Directory containing the input data files
+  directory: data/lb_test_data
+  # (Optional) Stem of the data file names. Default is "data"
+  data_file_stem: data
+  # Number of ranks (data files) expected
+  n_ranks: 4
+
+viz:
+  # Number of ranks along the X-axis
+  x_ranks: 2
+  # Number of ranks along the Y-axis
+  y_ranks: 2
+  # (Optional) Number of ranks along the Z-axis. Default is 1
+  z_ranks: 1
+  # (Optional) Adds jitter to the object positions. Default is 0.5
+  object_jitter: 0.5
+  # (Optional) Quantity of interest for ranks. Default is "load"
+  rank_qoi: load
+  # (Optional) Quantity of interest for objects. Default is "load"
+  object_qoi: load
+  # (Optional) Enable or disable saving of 3D meshes. Default is true
+  save_meshes: true
+  # (Optional) Enable or disable saving of PNG visualizations. Default is true
+  save_pngs: true
+  # (Optional) Force continuous quantities of interest for objects. Default is true
+  force_continuous_object_qoi: true
+
+output:
+  # (Optional) Directory for saving output files. Default is "output"
+  directory: output
+  # (Optional) Base name for output files. Default is "vttv"
+  file_stem: lb_test
+  # (Optional) Visualization window size in pixels. Default is 2000
+  window_size: 2000
+  # (Optional) Font size for visualizations. Default is 2.5% of the window size
+  font_size: 50
+```
+
+**Additional Notes:**
+
+- Output Directory:
+    The directory specified in `output.directory` must already exist. If it does not, `vt-tv` will fail during runtime.
+
+- Validation:
+    The number of files matching the pattern `input.data_file_stem.[integer].json` (with `[integer]` indicating the rank the file was generated for) in the `input.directory` must match the value of `input.n_ranks`.
+    The product of `viz.x_ranks`, `viz.y_ranks`, and `viz.z_ranks` must equal `input.n_ranks`.
+
 #### JSON Data Files
 
 Sample JSON data files are provided in `${VTTV_SOURCE_DIR}/tests/unit/lb_test_data`.

--- a/docs/md/mainpage.md
+++ b/docs/md/mainpage.md
@@ -83,6 +83,57 @@ A YAML configuration exemplar can be found in `${VTTV_SOURCE_DIR}/config/conf.ya
 ${VTTV_BUILD_DIR}/apps/vt_standalone -c config/conf.yaml
 ```
 
+The following is a complete description of possible keys that can be used in a configuration file:
+
+```yaml
+input:
+  # Directory containing the input data files
+  directory: data/lb_test_data
+  # (Optional) Stem of the data file names. Default is "data"
+  data_file_stem: data
+  # Number of ranks (data files) expected
+  n_ranks: 4
+
+viz:
+  # Number of ranks along the X-axis
+  x_ranks: 2
+  # Number of ranks along the Y-axis
+  y_ranks: 2
+  # (Optional) Number of ranks along the Z-axis. Default is 1
+  z_ranks: 1
+  # (Optional) Adds jitter to the object positions. Default is 0.5
+  object_jitter: 0.5
+  # (Optional) Quantity of interest for ranks. Default is "load"
+  rank_qoi: load
+  # (Optional) Quantity of interest for objects. Default is "load"
+  object_qoi: load
+  # (Optional) Enable or disable saving of 3D meshes. Default is true
+  save_meshes: true
+  # (Optional) Enable or disable saving of PNG visualizations. Default is true
+  save_pngs: true
+  # (Optional) Force continuous quantities of interest for objects. Default is true
+  force_continuous_object_qoi: true
+
+output:
+  # (Optional) Directory for saving output files. Default is "output"
+  directory: output
+  # (Optional) Base name for output files. Default is "vttv"
+  file_stem: lb_test
+  # (Optional) Visualization window size in pixels. Default is 2000
+  window_size: 2000
+  # (Optional) Font size for visualizations. Default is 2.5% of the window size
+  font_size: 50
+```
+
+**Additional Notes:**
+
+- Output Directory:
+    The directory specified in `output.directory` must already exist. If it does not, `vt-tv` will fail during runtime.
+
+- Validation:
+    The number of files matching the pattern `input.data_file_stem.[integer].json` (with `[integer]` indicating the rank the file was generated for) in the `input.directory` must match the value of `input.n_ranks`.
+    The product of `viz.x_ranks`, `viz.y_ranks`, and `viz.z_ranks` must equal `input.n_ranks`.
+
 #### JSON Data Files
 
 Sample JSON data files are provided in `${VTTV_SOURCE_DIR}/tests/unit/lb_test_data`.

--- a/src/vt-tv/utility/parse_render.cc
+++ b/src/vt-tv/utility/parse_render.cc
@@ -79,7 +79,7 @@ void ParseRender::parseAndRender(
 
       // Collect all file paths into a vector
       std::vector<std::filesystem::path> data_files;
-      std::regex pattern(data_file_stem + R"(\.\d+\.json)");
+      std::regex pattern(data_file_stem + R"(\.\d+\.json(\.br)?)");
 
       for (const auto& entry : std::filesystem::directory_iterator(input_dir)) {
         if (entry.is_regular_file()) {
@@ -134,9 +134,8 @@ void ParseRender::parseAndRender(
         utility::JSONReader reader{static_cast<NodeType>(rank)};
 
         // Validate the JSON data file
-        std::string data_file_path = input_dir + data_file_stem + "." + std::to_string(rank) + ".json";
-        if (reader.validate_datafile(data_file_path)) {
-          reader.readFile(data_file_path);
+        if (reader.validate_datafile(filepath)) {
+          reader.readFile(filepath);
           auto tmpInfo = reader.parse();
 
 #if VT_TV_OPENMP_ENABLED
@@ -145,7 +144,7 @@ void ParseRender::parseAndRender(
         { info->addInfo(tmpInfo->getObjectInfo(), tmpInfo->getRank(rank)); }
 
         } else {
-          throw std::runtime_error("JSON data file is invalid: " + data_file_path);
+          throw std::runtime_error("JSON data file is invalid: " + filepath);
         }
       }
 

--- a/src/vt-tv/utility/parse_render.cc
+++ b/src/vt-tv/utility/parse_render.cc
@@ -47,6 +47,7 @@
 #include "vt-tv/api/info.h"
 
 #include <filesystem>
+#include <regex>
 
 namespace vt::tv::utility {
 
@@ -77,8 +78,15 @@ void ParseRender::parseAndRender(
 
       // Collect all file paths into a vector
       std::vector<std::filesystem::path> data_files;
+      std::regex pattern(R"(data\.\d+\.json)");
+
       for (const auto& entry : std::filesystem::directory_iterator(input_dir)) {
-        data_files.push_back(entry.path());
+          if (entry.is_regular_file()) {
+              const std::string filename = entry.path().filename().string();
+              if (std::regex_match(filename, pattern)) {
+                  data_files.push_back(entry.path());
+              }
+          }
       }
 
       info = std::make_unique<Info>();

--- a/src/vt-tv/utility/parse_render.cc
+++ b/src/vt-tv/utility/parse_render.cc
@@ -59,6 +59,7 @@ void ParseRender::parseAndRender(
 
     if (info == nullptr) {
       std::string input_dir = config["input"]["directory"].as<std::string>();
+      std::string data_file_stem = config["input"]["file_stem"].as<std::string>("data");
       std::filesystem::path input_path(input_dir);
 
       // If it's a relative path, prepend the SRC_DIR
@@ -78,7 +79,7 @@ void ParseRender::parseAndRender(
 
       // Collect all file paths into a vector
       std::vector<std::filesystem::path> data_files;
-      std::regex pattern(R"(data\.\d+\.json)");
+      std::regex pattern(data_file_stem + R"(\.\d+\.json)");
 
       for (const auto& entry : std::filesystem::directory_iterator(input_dir)) {
         if (entry.is_regular_file()) {
@@ -133,7 +134,7 @@ void ParseRender::parseAndRender(
         utility::JSONReader reader{static_cast<NodeType>(rank)};
 
         // Validate the JSON data file
-        std::string data_file_path = input_dir + "data." + std::to_string(rank) + ".json";
+        std::string data_file_path = input_dir + data_file_stem + "." + std::to_string(rank) + ".json";
         if (reader.validate_datafile(data_file_path)) {
           reader.readFile(data_file_path);
           auto tmpInfo = reader.parse();


### PR DESCRIPTION
Fixes: #135 

Allows for other files to exist in data input directory without crashing vt-tv.